### PR TITLE
remove nvim from runtimeDeps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,14 +23,13 @@
         # Telescope
         # chafa 
         # ffmpegthumbnailer 
-	ripgrep
-	fd
+	    ripgrep
+	    fd
 	
 
         # Misc
         wakatime 
-	nerdfonts
-        nvim
+	    nerdfonts
       ];
 
       nvim = pkgs.wrapNeovimUnstable pkgs.neovim-unwrapped


### PR DESCRIPTION
This was causing the recursion
```nix
 runtimeDeps = with pkgs; [ 
     ...
     nvim # The final package is a dependency of itself
 ]
```